### PR TITLE
Fix #12: Extracting the return type before resolving dependencies

### DIFF
--- a/serum/_inject.py
+++ b/serum/_inject.py
@@ -98,7 +98,9 @@ def _decorate_function(f):
     def decorator(*args, **kwargs):
         positional_names = {name for name, arg in zip(names, args)}
         dependency_args = kwargs
-        for name, dependency in f.__annotations__.items():
+        annotations = f.__annotations__
+        return_type = annotations.pop('return', None)
+        for name, dependency in annotations.items():
             if name in dependency_args or name in positional_names:
                 continue
             if __is_dependency_decorated(dependency):


### PR DESCRIPTION
Adding a quick fix to the dependency resolution where return type was captured and passed as an unexpected keyword argument.