### PR TITLE
Quick-Fix for Supporting Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ general:
 jobs:
   test:
     docker:
-      - image: python:3.6
+      - image: python:3.5
     working_directory: ~/serum
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
           destination: htmlcov
   deploy:
     docker:
-      - image: python:3.6
+      - image: python:3.5
     working_directory: ~/serum
     steps:
       - checkout

--- a/Pipfile
+++ b/Pipfile
@@ -22,4 +22,4 @@ wheel = "*"
 ipython = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f2e7ffb8259126f10962b24a60d10acb331978d63534c861b66af3a37836d671"
+            "sha256": "b5b4426224b5b4c2dbb53c837e2013e0bbed20571b560f47bf29f61abfc84f6e"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.5"
         },
         "sources": [
             {
@@ -17,14 +17,6 @@
     },
     "default": {},
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
@@ -52,21 +44,6 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
-                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.3.9"
-        },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
         },
         "coverage": {
             "hashes": [
@@ -107,6 +84,7 @@
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
                 "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
+            "index": "pypi",
             "version": "==4.5.1"
         },
         "decorator": {
@@ -116,30 +94,13 @@
             ],
             "version": "==4.3.0"
         },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "flake8": {
             "hashes": [
                 "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
                 "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
             ],
+            "index": "pypi",
             "version": "==3.5.0"
-        },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.0'",
-            "version": "==1.0.2"
         },
         "idna": {
             "hashes": [
@@ -153,6 +114,7 @@
                 "sha256:85882f97d75122ff8cdfe129215a408085a26039527110c8d4a2b8a5e45b7639",
                 "sha256:a6ac981381b3f5f604b37a293369963485200e3639fb0404fa76092383c10c41"
             ],
+            "index": "pypi",
             "version": "==6.3.1"
         },
         "ipython-genutils": {
@@ -189,6 +151,7 @@
                 "sha256:caf58e717097735de0d7e15386a46ffa5ce25bb6a13a43716a8854a8d34841e2",
                 "sha256:cf5fa4f295dfb823cebdb27a00566113f2fbb71c7d5ca7b7a1019fd20c8a0811"
             ],
+            "index": "pypi",
             "version": "==0.6.1"
         },
         "parso": {
@@ -197,14 +160,6 @@
                 "sha256:a75a304d7090d2c67bd298091c14ef9d3d560e3c53de1c239617889f61d1d307"
             ],
             "version": "==0.2.0"
-        },
-        "pathlib2": {
-            "hashes": [
-                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
-                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
-            ],
-            "markers": "python_version in '2.6 2.7 3.2 3.3'",
-            "version": "==2.3.2"
         },
         "pexpect": {
             "hashes": [
@@ -283,16 +238,18 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
-                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
+                "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
+                "sha256:829230122facf05a5f81a6d4dfe6454a04978ea3746853b2b84567ecf8e5c526"
             ],
-            "version": "==3.5.0"
+            "index": "pypi",
+            "version": "==3.5.1"
         },
         "pytest-cov": {
             "hashes": [
                 "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
                 "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
             ],
+            "index": "pypi",
             "version": "==2.5.1"
         },
         "requests": {
@@ -309,27 +266,11 @@
             ],
             "version": "==0.8.0"
         },
-        "scandir": {
-            "hashes": [
-                "sha256:24f32112c483ac6c4a40b62f1282e61ecca7977153b66a0d26a9583a716dcb64",
-                "sha256:6c80092f8fe3e62c3da3110067589c6661c722b0889906d2974e5150f1314523",
-                "sha256:7729b8444c5f5187649ff58501e7c2ad22b84d7dc28f738f64c5b615913fec22",
-                "sha256:8e3ca5925cc13787aeafbf08f055a8066c091fc20bfa8783235b916cf047afbe",
-                "sha256:96dfc553f50946deb6d1cd762bac5cf122832c4aa253c885ca357ef53dd8d072",
-                "sha256:b2d55be869c4f716084a19b1e16932f0769711316ba62de941320bf2be84763d",
-                "sha256:b55a091b91f9e6c9c7129889b2f58df329530172a99172de9e784545342a45e6",
-                "sha256:b6cb611a18a828146a178362a36a2c6557c51c596ded4314cb516dd8c947b4ce",
-                "sha256:d985e36eb3effebb20434e6cd7495440b4ba676a22f3ec61e9fff9f3e2995238",
-                "sha256:f39dd5affde2860fb28176d2233f318ccca97c55019407ee8172b3fba0b211db",
-                "sha256:f91418e82edb5a43b020fa15e30a41d730b71c5957536749366bf63cc05427b1"
-            ],
-            "markers": "python_version < '3.5'",
-            "version": "==1.7"
-        },
         "semver": {
             "hashes": [
                 "sha256:1ffb55fb86a076cf7c161e6b5931f7da59f15abe217e0f24cea96cc8eec50f42"
             ],
+            "index": "pypi",
             "version": "==2.7.9"
         },
         "simplegeneric": {
@@ -347,10 +288,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:597e7526c85df881d51e094360181a84533aede1cb3f5a1cada8bbd4de557efd",
-                "sha256:fe3d218d5b61993d415aa2a9db6dd64c0e4cefb90164ebb197ef3b1d99f531dc"
+                "sha256:22c760d05b2eb6e96a91ad7ed1b03c9c97e6256fb7716410c27c2cb3265a5913",
+                "sha256:d7bfa112a55290a5e2d0c3263a09b17b24240686fbf20d1ef7c5e8edfbb71ad0"
             ],
-            "version": "==4.23.0"
+            "version": "==4.23.1"
         },
         "traitlets": {
             "hashes": [
@@ -364,16 +305,8 @@
                 "sha256:08eb132bbaec40c6d25b358f546ec1dc96ebd2638a86eea68769d9e67fe2b129",
                 "sha256:2fd9a4d9ff0bcacf41fdc40c8cb0cfaef1f1859457c9653fd1b92237cc4e9f25"
             ],
+            "index": "pypi",
             "version": "==1.11.0"
-        },
-        "typing": {
-            "hashes": [
-                "sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf",
-                "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
-                "sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2"
-            ],
-            "markers": "python_version <= '3.4'",
-            "version": "==3.6.4"
         },
         "urllib3": {
             "hashes": [
@@ -394,14 +327,8 @@
                 "sha256:1ae8153bed701cb062913b72429bcf854ba824f973735427681882a688cb55ce",
                 "sha256:9cdc8ab2cc9c3c2e2727a4b67c22881dbb0e1c503d592992594c5e131c867107"
             ],
+            "index": "pypi",
             "version": "==0.31.0"
-        },
-        "win-unicode-console": {
-            "hashes": [
-                "sha256:d4142d4d56d46f449d6f00536a73625a871cba040f0bc1a2e305a04578f07d1e"
-            ],
-            "markers": "sys_platform == 'win32' and python_version < '3.6'",
-            "version": "==0.5"
         }
     }
 }

--- a/serum/__init__.py
+++ b/serum/__init__.py
@@ -13,7 +13,7 @@ def load_ipython_extension(_):
     try:
         from ipython_context import context  # type: ignore
         context.__enter__()
-    except ModuleNotFoundError:
+    except ImportError:
         pass
 
 
@@ -21,5 +21,5 @@ def unload_ipython_extension(_):
     try:
         from ipython_context import context  # type: ignore
         context.__exit__(None, None, None)
-    except ModuleNotFoundError:
+    except ImportError:
         pass

--- a/serum/__init__.py
+++ b/serum/__init__.py
@@ -1,7 +1,12 @@
-from ._dependency import *
-from ._context import *
-from ._functions import *
-from ._inject import *
+from ._context import Context
+from ._dependency import dependency, singleton
+from ._functions import mock, match
+from ._inject import inject
+
+__all__ = [
+    'Context', 'dependency', 'singleton', 'inject', 'mock', 'match',
+    'load_ipython_extension', 'unload_ipython_extension',
+]
 
 
 def load_ipython_extension(_):

--- a/serum/_context.py
+++ b/serum/_context.py
@@ -1,7 +1,7 @@
 from copy import copy, deepcopy
 from unittest.mock import create_autospec, MagicMock
 from functools import wraps
-from typing import Type, Set, Union, Dict, TypeVar
+from typing import Type, Set, Union, Dict, TypeVar  # noqa
 
 from ._dependency_configuration import DependencyConfiguration
 from ._key import Key
@@ -19,13 +19,13 @@ T = TypeVar('T')
 
 class _LocalStorage(threading.local):
     def __init__(self):
-        self.current_env: Context = None
+        self.current_env = None  # type: Context
 
 
 class _ContextState(threading.local):
     def __init__(self):
-        self.pending: Set[Type[object]] = set()
-        self.old_current: Context = None
+        self.pending = set()  # type: Set[Type[object]]
+        self.old_current = None  # type: Context
         self.mocks: Dict[Union[str, Type[object]], MagicMock] = dict()
         self.singletons: Dict[Type[T], T] = dict()
 
@@ -80,8 +80,8 @@ class Context:
         :param args: Dependency decorated types to provide in this context
         :param kwargs: Named dependencies to provide in this context
         """
-        self.__registry: Set[Type[object]] = set()
-        self.__state: _ContextState = _ContextState()
+        self.__registry = set()  # type: Set[Type[object]]
+        self.__state = _ContextState()  # type: _ContextState
         self.__named_dependencies = kwargs
         self.__old_current = None
         for c in args:
@@ -239,7 +239,7 @@ class Context:
                 ) from e
             finally:
                 context.pending.remove(dependency_type)
-        dependency: Type[T] = configuration.dependency
+        dependency = configuration.dependency  # type: Type[T]
         if context.is_mocked(dependency):
             return context.get_mock(dependency)
         subtype = Context.find_subtype(dependency)

--- a/serum/_functions.py
+++ b/serum/_functions.py
@@ -8,7 +8,7 @@ from ._context import Context
 T = TypeVar('T')
 
 
-def mock(dependency: Union[str, Type[T]]) -> MagicMock:
+def mock(dependency: Union[str, T]) -> MagicMock:
     """
     Mock a dependency in the current environment
     :param dependency: The type to mock
@@ -19,7 +19,7 @@ def mock(dependency: Union[str, Type[T]]) -> MagicMock:
 
 
 def match(environment_variable: str,
-          default = None,  # type: Context
+          default=None,  # type: Context
           **environments) -> Context:
     """
     Match environment variable with Environment

--- a/serum/_functions.py
+++ b/serum/_functions.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Type, Union
+from typing import TypeVar, Type, Union  # noqa
 from unittest.mock import MagicMock
 
 import os
@@ -19,7 +19,7 @@ def mock(dependency: Union[str, Type[T]]) -> MagicMock:
 
 
 def match(environment_variable: str,
-          default: Context = None,
+          default = None,  # type: Context
           **environments) -> Context:
     """
     Match environment variable with Environment

--- a/serum/_inject.py
+++ b/serum/_inject.py
@@ -13,7 +13,7 @@ T = TypeVar('T')
 
 
 def __format_name(cls, name):
-    return f'_{cls.__name__}__{name}'
+    return '_{class_name}__{name}'.format(class_name=cls.__name__, name=name)
 
 
 def __is_dependency_decorated(dependency):
@@ -34,8 +34,8 @@ def __set_dependency(configuration: DependencyConfiguration, kwargs, name):
             setattr(configuration.owner, name, instance)
         except Exception as e:
             raise InjectionError(
-                f'Could not set attribute {configuration.name} on '
-                f'{configuration.owner}'
+                'Could not set attribute {name} on {owner}'
+                .format(name=configuration.name, owner=configuration.owner)
             ) from e
 
 

--- a/serum/_key.py
+++ b/serum/_key.py
@@ -1,6 +1,3 @@
-from typing import NamedTuple
+from collections import namedtuple
 
-
-class Key(NamedTuple):
-    dependency_type: type
-    name: str
+Key = namedtuple('Key', ['dependency_type', 'name'])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author='Sune Debel',
     license='MIT',
     author_email='sd@dybro-debel.dk',
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     url='https://github.com/suned/serum',
     keywords=['dependency-injection', 'solid', 'inversion-of-control'],
     classifiers=[],

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -44,8 +44,8 @@ class Key:
 
 @inject
 class Dependent:
-    some_singleton: SomeSingleton
-    some_component: SomeComponent
+    some_singleton = SomeSingleton
+    some_component = SomeComponent
 
 
 def configuration(d):
@@ -176,21 +176,21 @@ def test_circular_dependency():
 
     @inject
     class A(AbstractA):
-        b: AbstractB
+        b = AbstractB
 
         def __init__(self):
             self.b
 
     @inject
     class B(AbstractB):
-        a: AbstractA
+        a = AbstractA
 
         def __init__(self):
             self.a
 
     @inject
     class Dependent:
-        a: AbstractA
+        a = AbstractA
 
     with Context(A, B):
         pytest.raises(CircularDependency, lambda: Dependent().a)

--- a/test/test_inject.py
+++ b/test/test_inject.py
@@ -35,18 +35,18 @@ class AlternativeDependency(AbstractDependency):
 @dependency
 @inject
 class Chain:
-    some_component: SomeDependency
+    some_component = None  # type: SomeDependency
 
 
 @inject
 class Dependent:
-    some_dependency: SomeDependency
-    chain: Chain
+    some_dependency = None  # type: SomeDependency
+    chain = None  # type: Chain
 
 
 @inject
 class AbstractDependent:
-    abstract_dependency: AbstractDependency
+    abstract_dependency = None  # type: AbstractDependency
 
 
 class SubDependent(AbstractDependent):
@@ -59,12 +59,12 @@ class SubSubDependent(SubDependent):
 
 @inject
 class OverwriteDependent(AbstractDependent):
-    abstract_dependency: AlternativeDependency
+    abstract_dependency = None   # type: AlternativeDependency
 
 
 @inject
 class NamedDependent:
-    key: str
+    key = ''   # type: str
 
 
 def test_inject_gets_concrete_component():
@@ -152,7 +152,7 @@ def test_decorate_class_with_no_annotations():
 
 def test_decorate_class_with_no_dependency_annotations():
     class NoDependencyAnnotations:
-        a: int
+        a = None  # type: int
 
     decorated = inject(NoDependencyAnnotations)
     assert decorated is NoDependencyAnnotations
@@ -211,7 +211,7 @@ def test_invalid_class_dependencies():
 
     @inject
     class D:
-        _: BadDependency
+        _ = None  # type: BadDependency
 
     pytest.raises(InjectionError, lambda: D()._)
 
@@ -227,7 +227,7 @@ def test_subtype_is_bad_dependency():
 
     @inject
     class C:
-        _: D
+        _ = None  # type: D
 
     with Context(BadDependency):
         pytest.raises(InjectionError, lambda: C()._)
@@ -241,7 +241,7 @@ def test_dependency_raises_type_error():
 
     @inject
     class C:
-        _: BadDependency
+        _ = None   # type: BadDependency
 
     pytest.raises(InjectionError, lambda: C()._)
 
@@ -249,7 +249,7 @@ def test_dependency_raises_type_error():
 def test_no_named_dependency():
     @inject
     class C:
-        name: str
+        name = None   # type: str
 
     pytest.raises(NoNamedDependency, lambda: C().name)
 
@@ -270,7 +270,7 @@ def test_missing_init_dependencies():
 
     @inject
     class C:
-        d: D
+        d = None   # type: D
 
     pytest.raises(NoNamedDependency, lambda: C().d)
 
@@ -282,7 +282,7 @@ def test_inject_with_set_attr_override():
 
     @inject
     class C:
-        d: D
+        d = None   # type: D
 
         def __setattr__(self, key, value):
             raise AttributeError()

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -17,13 +17,13 @@ class SomeCallableComponent:
 
 @inject
 class Dependent:
-    some_component: SomeComponent
-    some_callable_component: SomeCallableComponent
+    some_component = None  # type: SomeComponent
+    some_callable_component = None  # type: SomeCallableComponent
 
 
 @inject
 class NamedDependent:
-    key: str
+    key = ''  # type: str
 
 
 def test_mock_always_replaces_component():


### PR DESCRIPTION
Fixes #17
- Reverting type-hinting for variables back to 3.5 way
- Updating the minimal requirements